### PR TITLE
 Add HLS upload support (m3u8, ts) + opt-in debug logging

### DIFF
--- a/nostr-media.php
+++ b/nostr-media.php
@@ -15,6 +15,17 @@ require __DIR__ . '/vendor/autoload.php';
 use swentel\nostr\Event\Event;
 use swentel\nostr\Key\Key;
 
+// Opt-in debug logging: define('NMU_DEBUG', true) in wp-config.php to enable.
+// Logs to wp-content/nostr-media-debug.log, independent of WP_DEBUG.
+if (!function_exists('nmu_log')) {
+    function nmu_log($msg) {
+        if (!defined('NMU_DEBUG') || !NMU_DEBUG) {
+            return;
+        }
+        @error_log('[' . date('c') . '] [nmu] ' . $msg . "\n", 3, WP_CONTENT_DIR . '/nostr-media-debug.log');
+    }
+}
+
 // Add the custom field to the profile page
 add_action('show_user_profile', 'nmu_add_custom_user_profile_fields');
 add_action('edit_user_profile', 'nmu_add_custom_user_profile_fields');
@@ -59,6 +70,7 @@ function nmu_save_custom_user_profile_fields($user_id) {
 // Check if the Authorization header matches valid NIP98 HTTP Auth 
 function nmu_validate_authorization_header($bodyHash = "") {
     $headers = getallheaders();
+    nmu_log('validate method=' . ($_SERVER['REQUEST_METHOD'] ?? '-') . ' uri=' . ($_SERVER['REQUEST_URI'] ?? '-') . ' remote=' . ($_SERVER['REMOTE_ADDR'] ?? '-') . ' auth=' . (isset($headers['Authorization']) ? ('yes(len=' . strlen($headers['Authorization']) . ')') : 'NO') . ' content_length=' . ($_SERVER['CONTENT_LENGTH'] ?? '?') . ' content_type=' . ($_SERVER['CONTENT_TYPE'] ?? '-'));
 
     if (isset($headers['Authorization'])) {
 
@@ -474,6 +486,12 @@ function nmu_processfile($movefile, $original_hash, $userId, $mime_type, $isBlos
         else if ($mime_type == "application/octet-stream") {
             $ext = "bin";
         }
+        else if ($mime_type == "application/vnd.apple.mpegurl" || $mime_type == "application/x-mpegurl") {
+            $ext = "m3u8";
+        }
+        else if ($mime_type == "video/mp2t") {
+            $ext = "ts";
+        }
     }
     $new_original_path = $pathinfo['dirname'] . '/' . $original_hash . '.' . $ext;
     rename($movefile['file'], $new_original_path);
@@ -746,6 +764,12 @@ function nmu_processfile_no_resize($movefile, $original_hash, $userId, $mime_typ
         else if ($mime_type == "application/octet-stream") {
             $ext = "bin";
         }
+        else if ($mime_type == "application/vnd.apple.mpegurl" || $mime_type == "application/x-mpegurl") {
+            $ext = "m3u8";
+        }
+        else if ($mime_type == "video/mp2t") {
+            $ext = "ts";
+        }
     }
     $new_original_path = $pathinfo['dirname'] . '/' . $original_hash . '.' . $ext;
     rename($movefile['file'], $new_original_path);
@@ -869,7 +893,10 @@ function nostr_custom_parse_request($wp) {
                 "audio/mp3",
                 "audio/mp4",
                 "audio/x-m4a",
-                "application/octet-stream"
+                "application/octet-stream",
+                "application/vnd.apple.mpegurl",
+                "application/x-mpegurl",
+                "video/mp2t"
             )
         );
 
@@ -1455,6 +1482,12 @@ function nmu_handle_mirror_put_request($wp) {
             else if ($mime_type == "application/octet-stream") {
                 $ext = "bin";
             }
+            else if ($mime_type == "application/vnd.apple.mpegurl" || $mime_type == "application/x-mpegurl") {
+                $ext = "m3u8";
+            }
+            else if ($mime_type == "video/mp2t") {
+                $ext = "ts";
+            }
          }
 
          if ($ext == "") {
@@ -1548,7 +1581,7 @@ function sha256_handle_request_uri() {
         } else {
 
             // Check common extensions
-            $extensions = ['jpg', 'webp', 'gif', 'png', 'mp4', 'bin'];
+            $extensions = ['jpg', 'webp', 'gif', 'png', 'mp4', 'bin', 'm3u8', 'ts'];
             foreach ($extensions as $try_ext) {
                 $file_path = WP_CONTENT_DIR . '/uploads/nostr/' . $prefix . '/' . $sha256 . '.' . $try_ext;
                 if (file_exists($file_path)) {

--- a/nostr-media.php
+++ b/nostr-media.php
@@ -1297,8 +1297,11 @@ function nmu_handle_upload_put_head_request($wp) {
         }
 
         // Get the raw input
+        $nmu_write_start = microtime(true);
+        nmu_log('upload write start content_length=' . ($_SERVER['CONTENT_LENGTH'] ?? '?'));
         $input = file_get_contents('php://input');
         if (empty($input)) {
+            nmu_log(sprintf('upload write end status=empty_body read_bytes=0 dur=%.3fs', microtime(true) - $nmu_write_start));
             status_header(400);
             exit('No file content provided');
         }
@@ -1306,6 +1309,7 @@ function nmu_handle_upload_put_head_request($wp) {
         // Create a temporary file
         $temp_file = tempnam(sys_get_temp_dir(), 'nostr_upload_');
         file_put_contents($temp_file, $input);
+        nmu_log(sprintf('upload write end status=ok read_bytes=%d tmp=%s dur=%.3fs', strlen($input), $temp_file, microtime(true) - $nmu_write_start));
 
         // Get content type from headers
         $content_type = $_SERVER['CONTENT_TYPE'] ?? '';


### PR DESCRIPTION
Summary

  Fixes HLS streaming upload support so that multi-file ABR ladders (master playlist, per-quality playlists, and segments) land on disk with correct extensions and produce URLs clients can actually fetch.

  The problem

  When a client uploads an HLS master or per-quality playlist with Content-Type: application/vnd.apple.mpegurl, the three nmu_processfile* fallback extension maps don't recognize the mime type. As a result:

  1. wp_handle_upload() can't infer an extension from wp_get_mime_types() either (HLS mime types aren't in WP's default allowlist).
  2. The plugin's fallback map has no case for application/vnd.apple.mpegurl, application/x-mpegurl, or video/mp2t.
  3. $ext stays empty, and the rename produces <hash>. — a file ending in a bare trailing dot with no extension.
  4. The URL returned in the NIP-96 response looks like …/nostr/x/y/<hash>. (with the dot but no extension).
  5. Clients can't fetch the file cleanly — Apache may serve it, but clients that append or validate extensions break, cache layers get split, and Blossom BUD-01 GET /<sha256> can't locate the file because m3u8/ts aren't in
  the $extensions probe array either.

  Reproduced live on an HLS upload session: 5 of 11 files (every .m3u8) landed as bare-dot files on disk and triggered 404s on playback. Discovered, debugged, and verified fixed against a real deployment.

  What this PR changes

  - nmu_processfile() fallback map — adds application/vnd.apple.mpegurl / application/x-mpegurl → m3u8, and video/mp2t → ts.
  - nmu_processfile_no_resize() — same additions.
  - nmu_handle_mirror_put_request() fallback map — same additions (mirror/BUD-04 path).
  - nip96.json content_types discovery list — adds the three HLS mime types so NIP-96 clients that validate against discovery will accept HLS uploads.
  - $extensions probe in sha256_handle_request_uri() — adds m3u8 and ts so that extensionless Blossom GET /<sha256> requests can locate HLS files on disk. (Still recommend clients use the extension form directly for HLS
  playback — fewer redirects, cleaner Content-Type, cleaner range requests.)
  - Opt-in debug logging — adds a small nmu_log() helper that writes to wp-content/nostr-media-debug.log, gated by define('NMU_DEBUG', true) in wp-config.php. No-op by default, independent of WP_DEBUG. One entry-point log in
   nmu_validate_authorization_header() that captures method, URI, remote IP, auth presence and length, content-length, content-type. Invaluable when diagnosing client upload issues without scraping the webserver access log.

  Diff: +35 / −2 in nostr-media.php, no new files, no version bump (maintainer's call).

  Verification

  Deployed to a production WordPress on cPanel/LSAPI PHP 8.1.34 and exercised end-to-end with https://github.com/vitorpamplona/amethyst (nostr client with HLS support):

  - ✅ 11-file HLS ABR ladder upload (1 master + 5 per-quality playlists + 5 segment variants at 360p→2160p) completes with 11 × 200 responses
  - ✅ Files land on disk with correct .m3u8 and .mp4 extensions (previously bare-dot for m3u8s)
  - ✅ Master playlist's rewritten segment URLs resolve correctly (previously produced ..m3u8 double-dot on the client side due to the broken server URL)
  - ✅ Multiple independent clients successfully play back the same upload: Amethyst 1.04.2/1.08.0 on Android, Safari via iris.to, ffmpeg/libav crawlers — all fetching /wp-content/uploads/nostr/…/*.m3u8 with HTTP 200 and
  correct Content-Type: application/vnd.apple.mpegurl
  - ✅ nip96.json discovery endpoint returns the expanded content_types list
  - ✅ NIP-98 auth validation still works unchanged
  - ✅ No PHP errors or warnings triggered by the new code paths

  Server config note for other LSAPI/cPanel users who may hit this: if uploads fail with "Missing Authorization header" even though the client sends one, the site's .htaccess also needs a rewrite to forward the Authorization
   header into PHP's $_SERVER — this is a known LSAPI/FastCGI quirk, not caused by this PR:

  <IfModule mod_rewrite.c>
  RewriteEngine On
  RewriteCond %{HTTP:Authorization} ^(.+)$
  RewriteRule .* - [E=HTTP_AUTHORIZATION:%1]
  </IfModule>

  Compatibility

  - No database changes
  - No user-facing setting changes
  - No new dependencies
  - Purely additive to existing code paths — existing image/video/audio uploads continue to work identically
  - The nmu_log() helper is a no-op unless NMU_DEBUG is explicitly defined

  Notes

  - I did not bump the Version: header — happy to defer to your release cadence.
  - **The $extensions probe array still doesn't cover several extensions the upload path can produce** (mp3, m4a, aac, ogg, opus, mov, webm, avif, svg, tiff, pdf, etc.) — that's a pre-existing issue unrelated to HLS. Can be a
  follow-up.